### PR TITLE
[WIP]Allow to automatically set counter part account on bank statement lin…

### DIFF
--- a/account_statement_completion_label_simple/models/account_bank_statement.py
+++ b/account_statement_completion_label_simple/models/account_bank_statement.py
@@ -46,3 +46,28 @@ class AccountBankStatement(models.Model):
             return True
         else:
             return False
+
+    def button_post(self):
+        super().button_post()
+        account_st_lines = self.line_ids.filtered(lambda l: l.account_id)
+        for st_line in account_st_lines:
+            liquidity_lines, suspense_lines, other_lines = st_line._seek_for_lines()
+            (suspense_lines + other_lines).write({
+                'account_id': st_line.account_id.id,
+            })
+        account_st_lines._compute_is_reconciled()
+
+
+class AccountBankStatementLine(models.Model):
+    _inherit = 'account.bank.statement.line'
+
+    account_id = fields.Many2one('account.account')
+
+    # Note it does not seem usefull to override _synchronize_from_moves :
+    # indeed, the move's account_id can't be modified if move is posted and the
+    # move can't go back to draft if st line is validated. So for the move account_id to
+    # change, statement needs to go back to draft which reset all amt to suspend account
+    # anyway
+    # _synchronize_to_moves does not seem usefull for the same reason, statement line
+    # can only change when statement is draft...the in case of change, it will be
+    # be propataged to the move during the statement posting

--- a/account_statement_completion_label_simple/views/account_bank_statement.xml
+++ b/account_statement_completion_label_simple/views/account_bank_statement.xml
@@ -25,6 +25,9 @@
         <xpath expr="//field[@name='line_ids']/tree/field[@name='payment_ref']" position="after">
             <button name="%(account_statement_completion_label_simple.account_statement_label_create_action)d" type="action" string="Learn Label" icon="fa-save" attrs="{'invisible': [('partner_id', '!=', False)]}"/>
         </xpath>
+        <xpath expr="//field[@name='line_ids']/tree/field[@name='partner_id']" position="after">
+            <field name="account_id" optional="hidden"/>
+        </xpath>
     </field>
 </record>
 

--- a/account_statement_completion_label_simple/views/account_statement_label.xml
+++ b/account_statement_completion_label_simple/views/account_statement_label.xml
@@ -17,7 +17,7 @@
             <group name="main">
                 <field name="label"/>
                 <field name="partner_id"/>
-                <!-- <field name="account_id"/> -->
+                <field name="account_id"/>
                 <field name="company_id" groups="base.group_multi_company"/>
             </group>
         </form>
@@ -31,7 +31,7 @@
         <tree string="Statement Labels" editable="bottom">
             <field name="label"/>
             <field name="partner_id"/>
-            <!-- <field name="account_id"/> -->
+            <field name="account_id"/>
             <field name="company_id" groups="base.group_multi_company"/>
         </tree>
     </field>
@@ -44,7 +44,7 @@
         <search string="Search Statement Labels" >
             <field name="label"/>
             <field name="partner_id"/>
-            <!-- <field name="account_id"/>  -->
+            <field name="account_id"/>
             <group string="Group By" name="groupby">
                 <filter name="partner_groupby" string="Partner"
                     context="{'group_by': 'partner_id'}"/>

--- a/account_statement_completion_label_simple/wizard/account_statement_label_create.py
+++ b/account_statement_completion_label_simple/wizard/account_statement_label_create.py
@@ -33,11 +33,13 @@ class AccountStatementLabelCreate(models.TransientModel):
     partner_id = fields.Many2one(
         'res.partner', string='Partner', domain=[('parent_id', '=', False)],
         required=True)
+    account_id = fields.Many2one('account.account')
 
     def run(self):
         self.ensure_one()
         self.env['account.statement.label'].create({
             'partner_id': self.partner_id.id,
+            'account_id': self.account_id.id or False,
             'label': self.new_label.strip(),
             'company_id': self.statement_line_id.company_id.id,
         })

--- a/account_statement_completion_label_simple/wizard/account_statement_label_create_view.xml
+++ b/account_statement_completion_label_simple/wizard/account_statement_label_create_view.xml
@@ -17,6 +17,7 @@
                 <field name="current_label"/>
                 <field name="new_label"/>
                 <field name="partner_id" context="{'default_is_company': True}"/>
+                <field name="account_id"/>
             </group>
             <footer>
                 <button type="object" name="run" string="Create Label and Update"


### PR DESCRIPTION
…e to avoid the reconciliation step


Not sure it is still relevant, account.reconcile.model allow to do this.
- Create a account.reconcile.model depending on label and configure partner and account.
Still, is does not seem so good because all account.reconcile.model will always be checked whatever partner is set or not on bank statement line.

