### PR TITLE
[14] Add a hook on update_statement_lines

### DIFF
--- a/account_statement_completion_label_simple/models/account_journal.py
+++ b/account_statement_completion_label_simple/models/account_journal.py
@@ -29,13 +29,6 @@ class AccountJournal(models.Model):
         "bank statement line if it contains a customer invoice/refund number "
         "of that partner.")
 
-    automate_entry = fields.Boolean(
-        string="Automate Counterpart",
-        default=True,
-        help="If enabled, pre-recorded bank statement labels "
-        "configured with a counter-part account will be used to automatically set "
-        "the counter-part journal item and validate the bank statement line.")
-
     def get_all_labels(self):
         self.ensure_one()
         dataset = []

--- a/account_statement_completion_label_simple/views/account_journal.xml
+++ b/account_statement_completion_label_simple/views/account_journal.xml
@@ -17,7 +17,6 @@
                 <field name="partner_autocompletion"/>
                 <field name="invoice_number_autocompletion"/>
                 <field name="statement_label_autocompletion"/>
-                <field name="automate_entry" attrs="{'invisible': [('statement_label_autocompletion', '=', False)]}"/>
             </group>
         </xpath>
     </field>


### PR DESCRIPTION
@alexis-via replace the closed PR https://github.com/akretion/bank-statement-reconcile-simple/pull/4
I am ok to not add a new module for the counterpart account functionality, I though you would prefer, but I am fine if it stays in the main module.
I am also fine with the way you changed it to not depends on `account_reconciliation_widget`

But, some hook I had done was also to be able to do more stuff in the custom part of customers.
For instance, I need to fill a new field "sale_id" on the statement line, when the rule from `account_statement_completion_label_simple_sale` is used.

I refactored this part on my side, but still need a hook in `update_statement_lines` to be able to do it.
Also, I made a separated method for the update of the counterpart account, since I may want to re-use it.

I think these 2 small hooks don't hurt anyone, do you agree ?

Last thing, I removed the `automate_entry` field since it seems it is not used anywhere.